### PR TITLE
Tool-Breaking Bug fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,11 +13,11 @@
 	chrome.extension.onMessage.addListener(function (request, sender, sendResponse) {
 		switch (request.functiontoInvoke) {
 			case "readSelectedText":
-				getReadOptions();
+				// getReadOptions();
 				playReadContent( request.selectedText );
 				break;
 			case "readFullPage":
-				getReadOptions();
+				// getReadOptions();
 				var getArticle = $.get( 'https://readparser.herokuapp.com/?url=' + document.URL );
 				getArticle.success(function( result ) {
 					playReadContent( result );
@@ -84,17 +84,23 @@
 		});
 	}
 
-	function getReadOptions () {
+	// function getReadOptions () {
+	// 	chrome.storage.sync.get(null, function ( myOptions ) {
+	// 		readOptions = $.extend( {}, readOptions, myOptions );
+	// 		//console.log('[READ] get:', readOptions);
+	// 		r = new Read ( readOptions );
+	// 	});
+	// }
+
+	function playReadContent ( text ) {
 		chrome.storage.sync.get(null, function ( myOptions ) {
 			readOptions = $.extend( {}, readOptions, myOptions );
 			//console.log('[READ] get:', readOptions);
 			r = new Read ( readOptions );
-		});
-	}
 
-	function playReadContent ( text ) {
-		r.setText(text);
-		r.play();
+			r.setText(text);
+			r.play();
+		});
 	}
 
 })();

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@
 								text += " " + elementText;
 					});
 					playReadContent(text);
-				}
+				});
 				break;
 			default:
 				break;


### PR DESCRIPTION
Some stuff got broken in a recent change. The separation of getReadOptions and playReadOptions ended up leaving playReadOptions with an undefined variable `r`. Wasn't sure how you want to handle it, but this is a possible fix. The code that was in `getReadOptions` is still only being called once.

Also fixes a small typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jamestomasino/read_plugin/12)
<!-- Reviewable:end -->
