### PR TITLE
Centers non-English text (example: Greek)

### DIFF
--- a/Read.js
+++ b/Read.js
@@ -56,18 +56,6 @@
 			</div>\
 		</div>';
 
-	$.fn.textWidth = function(){
-		var self = $(this),
-			children = self.contents(),
-			calculator = $('<span style="display: inline-block;" />'),
-			width;
-
-		children.wrap(calculator);
-		width = children.parent().width();
-		children.unwrap();
-		return width;
-	};
-
 	var defaultOptions = {
 		wpm: 300,
 		slowStartCount: 5,
@@ -175,11 +163,8 @@
 			var $before = this._options.element.find('.__read_before').html(before).css("opacity","0");
 			var $letter = this._options.element.find('.__read_letter').html(letter).css("opacity","0");
 
-			var calc = $before.textWidth() + Math.round( $letter.textWidth() / 2 );
-
 			if (!this._currentWord.val.match(whiteSpace)){
 				this._displayElement.html(this._currentWord.val);
-				this._displayElement.css("margin-left", -calc);
 			}
 		}
 

--- a/main.css
+++ b/main.css
@@ -2511,6 +2511,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   font-size: 30px;
   cursor: pointer;
 }
+/* Start centering words more flexibly (works for languages other than English) */
+.__read .__read_bar .__read_position {
+  text-align: center;
+}
+.__read .__read_bar .__read_position .__read_display,
+.__read .__read_bar .__read_position .__read_indicator {
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
 /* line 77, ../scss/_read.scss */
 .__read .__read_bar .__read_position .__read_before,
 .__read .__read_bar .__read_position .__read_letter {


### PR DESCRIPTION
Try article sites at https://el.wikipedia.org/

This uses CSS to center instead of javascript calculations (which weren't working for languages other than English).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jamestomasino/read_plugin/13)
<!-- Reviewable:end -->
